### PR TITLE
docs: add deployment prerequisites and troubleshooting notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,12 @@ aws configure
 
 Locally installing on a workstation requires the following steps. 
 
-1. Locally install [Docker](https://www.docker.com/ja-jp/) and Docker Daemon is running
+1. Locally install [Docker](https://www.docker.com/ja-jp/) and Docker Daemon is running (required for CDK asset bundling)
 1. Locally install AWS CDK as the [official documentation](https://docs.aws.amazon.com/cdk/latest/guide/getting_started.html) describes.
+    - **Keep the CDK CLI up to date.** This project pins `aws-cdk-lib` to a recent version. If the CLI is older than the library you will see a *"Cloud assembly schema version mismatch"* error during `cdk synth`. Upgrade with `npm install -g aws-cdk@latest` (CLI >= 2.1132.0 is known to work).
 1. [Bootstrap CDK for AWS Account](https://github.com/aws/aws-cdk/blob/master/design/cdk-bootstrap.md) 
-1. Install Python >=3.6 from [python.org](http://python.org/)
+1. Install Python (>=3.9, **<=3.13 recommended**) from [python.org](http://python.org/)
+    - Python 3.14 currently fails to create a virtualenv here (`ensurepip` error). Use Python 3.13 or earlier, e.g. `python3.13 -m venv .venv`.
 1. Create a Python virtual environment
   ```sh
   python3 -m venv .venv                                      
@@ -65,6 +67,23 @@ export RFL_STACK_NAME=Rfl-Prod
 # Running this command will install any dependencies (brew, yum, or apt required)
 # After preparing the local machine it will synthesize and deploy into your environment.
 ./one-click.sh
+```
+
+> **Note on region:** CDK resolves the target region from `AWS_REGION` / `AWS_DEFAULT_REGION` first, then falls back to the profile's `aws configure get region`. If an `AWS_REGION` env var is set to something other than what you intend, the stack deploys there. Unset it or export the region explicitly before deploying:
+> ```sh
+> export CDK_DEFAULT_REGION=us-east-1
+> ```
+
+### Deploying without one-click.sh (manual CDK)
+
+`one-click.sh` is interactive and assumes `awscliv2` (the pip package). If you already have the AWS CLI and CDK configured, you can deploy directly:
+
+```sh
+python3.13 -m venv .venv
+source .venv/bin/activate
+pip install -r infra/requirements.txt
+export RFL_STACK_NAME=Rfl-Dev            # use a distinct name to avoid clobbering an existing stack
+cdk deploy -a "python3 app.py" --require-approval never
 ```
 
 

--- a/docs/README_ja.md
+++ b/docs/README_ja.md
@@ -24,10 +24,12 @@ aws configure
 
 ローカル環境にインストールするには、以下の手順が必要です。
 
-1. [Docker](https://www.docker.com/ja-jp/)をローカルにインストールし、Docker Daemonを実行します。
+1. [Docker](https://www.docker.com/ja-jp/)をローカルにインストールし、Docker Daemonを実行します(CDKのアセットバンドルに必要です)。
 1. 公式ドキュメンテーション[の説明](https://docs.aws.amazon.com/cdk/latest/guide/getting_started.html)に従ってAWS CDKをローカルにインストールします。
+    - **CDK CLIは最新に保ってください。** 本プロジェクトは`aws-cdk-lib`を比較的新しいバージョンに固定しています。CLIがライブラリより古いと`cdk synth`時に *"Cloud assembly schema version mismatch"* エラーが発生します。`npm install -g aws-cdk@latest`で更新してください(CLI >= 2.1132.0で動作確認済み)。
 1. [AWSアカウントにCDKを初期化](https://github.com/aws/aws-cdk/blob/master/design/cdk-bootstrap.md)します。
-1. [python.org](http://python.org/)からPython 3.6以降をインストールします。
+1. [python.org](http://python.org/)からPython(3.9以降、**3.13以下を推奨**)をインストールします。
+    - Python 3.14では現状virtualenvの作成に失敗します(`ensurepip`エラー)。Python 3.13以前を使用してください。例: `python3.13 -m venv .venv`
 1. Pythonの仮想環境を作成します。
   ```sh
   python3 -m venv .venv
@@ -59,6 +61,23 @@ export RFL_STACK_NAME=Rfl-Prod
 # このコマンドを実行すると、依存関係(brew、yum、aptが必要な場合)がインストールされます。
 # ローカルマシンの準備ができた後、環境にシンセサイズおよびデプロイされます。
 ./one-click.sh
+```
+
+> **リージョンに関する注意:** CDKはデプロイ先リージョンを、まず`AWS_REGION` / `AWS_DEFAULT_REGION`環境変数から解決し、次にプロファイルの`aws configure get region`にフォールバックします。意図しない値の`AWS_REGION`が設定されていると、そのリージョンにデプロイされます。デプロイ前に環境変数を解除するか、明示的にリージョンを指定してください:
+> ```sh
+> export CDK_DEFAULT_REGION=us-east-1
+> ```
+
+### one-click.shを使わない手動デプロイ(CDK直接実行)
+
+`one-click.sh`は対話式で、`awscliv2`(pipパッケージ)を前提としています。すでにAWS CLIとCDKが設定済みであれば、直接デプロイできます:
+
+```sh
+python3.13 -m venv .venv
+source .venv/bin/activate
+pip install -r infra/requirements.txt
+export RFL_STACK_NAME=Rfl-Dev            # 既存スタックを上書きしないよう別名を使用
+cdk deploy -a "python3 app.py" --require-approval never
 ```
 
 ## Amplifyアプリをローカルで実行するにはどうすればよいですか?


### PR DESCRIPTION
## 概要

現リポジトリが正しくデプロイ・動作するかを検証するため、既存の `Rfl-Prod` を壊さないよう **別スタック名 `Rfl-Dev` で新規デプロイして E2E 確認**しました。

**結論: コードは無修正で正常に動作しました。** 全82リソースが `CREATE_COMPLETE` となり、フロントエンド(SessionID発行、3タブUI、Face Liveness/類似度チェック)もブラウザで正常描画を確認済みです。

一方で、デプロイ時に詰まったポイントはすべて **環境要因**(古いツールバージョン等)でした。次の人が同じ所で詰まらないよう、README にトラブルシューティングを追記します。

## 変更内容

`README.md` と `docs/README_ja.md` に以下を追記:

| 追記項目 | 背景 |
|---|---|
| CDK CLI を最新に保つ注意 | CLIが `aws-cdk-lib` より古いと `cdk synth` で *Cloud assembly schema version mismatch* が発生(CLI >= 2.1132.0 で動作確認) |
| Python バージョン推奨 (<=3.13) | Python 3.14 は `ensurepip` エラーで venv 作成に失敗 |
| Docker が必須である旨 | CDK アセットのバンドルに必要 |
| リージョン解決の優先順位 | `AWS_REGION` 環境変数がプロファイルのリージョンを上書きする(意図しないリージョンにデプロイされる) |
| `one-click.sh` を使わない手動 CDK デプロイ手順 | 対話式スクリプトを使わずに済む代替手順 |

## 検証

- `cdk deploy` → 全82リソース `CREATE_COMPLETE`(約4分)
- Amplify フロントビルド `SUCCEED`、フロントエンド HTTP 200
- ブラウザで UI 描画・SessionID 発行を確認

## 補足

- ドキュメントのみの変更で、インフラ/アプリのコードは変更していません。
- 検証用の `Rfl-Dev` スタック(us-west-2)は必要に応じて `cdk destroy` で削除可能です。